### PR TITLE
Moves delimiter defaulting back down to parser

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,14 +5,13 @@ var hl = require('highland');
 var glob = require('glob');
 var path = require('path');
 var program = require('commander');
-var config = require('./lib/config');
 var stubbifier = require('./lib/stubbifier');
 
 program._name = 'stubbify';
 program._usage = '[file ...] [targetDir]';
 
 program
-  .version('0.1.0')
+  .version('0.1.1')
   .option('-b, --begin-stub [string]', 'RegEx string (JS-style) for stub begin delimiter (case-insensitive)')
   .option('-e, --end-stub [string]', 'RegEx string (JS-style) for stub end delimiter (case-insensitive)')
   .option('-s, --silent', 'Suppress printing of stubbified file paths')
@@ -23,19 +22,8 @@ if (program.args.length < 2) {
   process.exit();
 }
 
-var beginStub = config.defaultBeginStub;
-var endStub = config.defaultEndStub;
-
-if (program.beginStub !== undefined) {
-  beginStub = new RegExp(program.beginStub, 'i');
-}
-
-if (program.endStub !== undefined) {
-  endStub = new RegExp(program.endStub, 'i');
-}
-
 var targetDir = program.args.pop();
-var stubbify = stubbifier(targetDir, beginStub, endStub);
+var stubbify = stubbifier(targetDir, program.beginStub, program.endStub);
 
 hl(program.args)
   .flatMap(hl.wrapCallback(glob)).series()

--- a/lib/stubbifier.js
+++ b/lib/stubbifier.js
@@ -2,10 +2,15 @@ var hl = require('highland');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
+var config = require('./config');
 
 var cwd = process.cwd();
 
 var parser = function (beginStub, endStub) {
+  beginStub = beginStub || config.defaultBeginStub;
+  beginStub = typeof beginStub === 'string' ? RegExp(beginStub, 'i') : beginStub;
+  endStub = endStub || config.defaultEndStub;
+  endStub = typeof endStub === 'string' ? RegExp(endStub, 'i') : endStub;
   var pushing = true;
 
   return function parse(err, line, push, next) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stubbify",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Stubbify files so that some code isn't included.",
   "main": "lib/stubbifier.js",
   "scripts": {

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -3,7 +3,6 @@
 var hl = require('highland');
 var chai = require('chai');
 var parser = require('../lib/stubbifier').parser;
-var config = require('../lib/config');
 
 var assert = chai.assert;
 
@@ -11,7 +10,7 @@ var makeTest = function (input, expected) {
   return function (done) {
     hl([input])
       .split()
-      .consume(parser(config.defaultBeginStub, config.defaultEndStub))
+      .consume(parser())
       .intersperse('\n')
       .toArray(function (lines) {
         assert.strictEqual(expected, lines.join(''));

--- a/test/stubbify_test.js
+++ b/test/stubbify_test.js
@@ -4,17 +4,16 @@ var chai = require('chai');
 var del = require('del');
 var fs = require('fs');
 var stubbifier = require('../lib/stubbifier');
-var config = require('../lib/config');
 
 var assert = chai.assert;
 
 describe('#stubbify', function () {
   var fixturesPath = './test/fixtures/';
   var targetDir = fixturesPath + 'tmp';
-  var htmlStubbify = stubbifier(targetDir, /^.*<!--[\s]*STUB[\s]*-->/, /^.*<!--[\s]*ENDSTUB[\s]*-->/);
+  var htmlStubbify = stubbifier(targetDir, '^.*<!--[\\s]*STUB[\\s]*-->', '^.*<!--[\\s]*ENDSTUB[\\s]*-->');
 
   var stubbifyAndCompare = function (input, expected, stubbify) {
-    stubbify = stubbify || stubbifier(targetDir, config.defaultBeginStub, config.defaultEndStub);
+    stubbify = stubbify || stubbifier(targetDir);
     var inputPath = fixturesPath + input;
     var outputPath = fixturesPath + 'tmp/test/fixtures/' + input;
     var expectedPath = fixturesPath + expected;


### PR DESCRIPTION
Makes `stubbifier` more self-contained for the grunt plugin and bumps version to 0.1.1
